### PR TITLE
Update of ApiResource should return a boolean

### DIFF
--- a/src/IdentityServer.EF.DataAccess/ApiResourcesRepository.cs
+++ b/src/IdentityServer.EF.DataAccess/ApiResourcesRepository.cs
@@ -31,10 +31,11 @@ namespace IdentityServer.EF.DataAccess
             await _dbContext.SaveChangesAsync();
         }
 
-        public async Task UpdateApiResource(ApiResource apiResource)
+        public async Task<bool> UpdateApiResource(ApiResource apiResource)
         {
             _dbContext.ApiResources.Update(apiResource);
-            await _dbContext.SaveChangesAsync();
+            var result = await _dbContext.SaveChangesAsync();
+            return result > 0;
         }
 
         public async Task DeleteApiResource(int id)

--- a/src/IdentityServer.EF.DataAccess/IApiResourcesRepository.cs
+++ b/src/IdentityServer.EF.DataAccess/IApiResourcesRepository.cs
@@ -9,7 +9,7 @@ namespace IdentityServer.EF.DataAccess
         Task<List<ApiResource>> GetApiResources();
         Task<ApiResource> GetApiResourceById(int id);
         Task CreateApiResource(ApiResource apiResource);
-        Task UpdateApiResource(ApiResource apiResource);
+        Task<bool> UpdateApiResource(ApiResource apiResource);
         Task DeleteApiResource(int id);
     }
 }

--- a/src/IdentityServerAspNetIdentity/Pages/Admin/ApiResources/Edit.cshtml
+++ b/src/IdentityServerAspNetIdentity/Pages/Admin/ApiResources/Edit.cshtml
@@ -33,4 +33,10 @@
         <input asp-for="ApiResource.RequireResourceIndicator" type="checkbox" />
     </div>
     <button type="submit">Save</button>
+    @if (Model.ApiResource == null)
+    {
+        <div>
+            <span>Update failed. Please try again.</span>
+        </div>
+    }
 </form>


### PR DESCRIPTION
Update the `UpdateApiResource` method to return a boolean indicating success or failure.

* Change the return type of `UpdateApiResource` method in `ApiResourcesRepository.cs` to `Task<bool>` and return `true` if the update is successful, `false` otherwise.
* Update the `IApiResourcesRepository` interface to reflect the new return type of `UpdateApiResource` method.
* Modify the `Edit` page model in `Edit.cshtml.cs` to handle the boolean return value from `UpdateApiResource` method.
* Add a message in the `Edit` page in `Edit.cshtml` to inform the user if the update fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ColmKenna/BasicIdentityServerStarter/pull/24?shareId=8e63b2ae-4856-424d-91f1-f8d82164b4b2).